### PR TITLE
Be flexibile with whitespace.

### DIFF
--- a/XcodeIssueGenerator/TagFinder.swift
+++ b/XcodeIssueGenerator/TagFinder.swift
@@ -108,7 +108,7 @@ struct TagFinder {
     private func makeRegexWithTags(tags: [String]?) -> NSRegularExpression? {
         guard let tags = tags else { return nil }
 
-        let pattern = "// (\(tags.joinWithSeparator("|"))):.*$"
+        let pattern = "//\\s*(\(tags.joinWithSeparator("|"))):.*$"
 
         do {
             return try NSRegularExpression(pattern: pattern, options: [])


### PR DESCRIPTION
We want to allow comments like //TEMP to be picked up.
We'll update our regex to allow that.